### PR TITLE
refactor: 2アカウントから1アカウントへの移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,7 @@
-# ソースユーザー（お気に入り曲を取得するユーザー）の認証情報
-SOURCE_CLIENT_ID=your_source_client_id
-SOURCE_CLIENT_SECRET=your_source_client_secret
-SOURCE_REFRESH_TOKEN=your_source_refresh_token
-
-# ターゲットユーザー（プレイリストに曲を追加するユーザー）の認証情報
-TARGET_CLIENT_ID=your_target_client_id
-TARGET_CLIENT_SECRET=your_target_client_secret
-TARGET_REFRESH_TOKEN=your_target_refresh_token
+# Spotifyアカウントの認証情報
+CLIENT_ID=your_client_id
+CLIENT_SECRET=your_client_secret
+REFRESH_TOKEN=your_refresh_token
 
 # 同期先のプレイリストID
-TARGET_PLAYLIST_ID=your_target_playlist_id
+PLAYLIST_ID=your_playlist_id

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Run sync
         run: pnpm start
         env:
-          SOURCE_CLIENT_ID: ${{ secrets.SOURCE_CLIENT_ID }}
-          SOURCE_CLIENT_SECRET: ${{ secrets.SOURCE_CLIENT_SECRET }}
-          SOURCE_REFRESH_TOKEN: ${{ secrets.SOURCE_REFRESH_TOKEN }}
-          TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID }}
-          TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET }}
-          TARGET_REFRESH_TOKEN: ${{ secrets.TARGET_REFRESH_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           TARGET_PLAYLIST_ID: ${{ secrets.TARGET_PLAYLIST_ID }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Spotify Playlist Sync
 
-このプロジェクトは、GitHub Actionsを使用して定期的に特定のSpotifyユーザーのお気に入りに追加された曲を、別ユーザーの特定のプレイリストに自動的に追加するツールです。
+このプロジェクトは、GitHub Actionsを使用して定期的にSpotifyユーザーのお気に入りに追加された曲を、特定のプレイリストに自動的に同期するツールです。
 
 ## 機能
 
-- 特定のSpotifyユーザーのお気に入り曲を取得
+- お気に入り曲を取得
 - プレイリストに未追加の曲を特定
-- 別ユーザーの特定プレイリストに新しい曲を追加
+- プレイリストに新しい曲を追加
+- プレイリストから削除された曲を削除
 - GitHub Actionsによる定期的な実行
 
 ## セットアップ方法
 
 ### 1. Spotify開発者アカウントの設定
-
-両方のSpotifyアカウント（ソースとターゲット）に対して以下の手順を実行します：
 
 1. [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/applications)にログイン
 2. 新しいアプリケーションを作成
@@ -32,41 +31,30 @@
    ```
    pnpm i --frozen-lockfile
    ```
-3. `.env.example`を`.env`にコピーして、必要な情報を入力（`SOURCE_REFRESH_TOKEN`、`TARGET_REFRESH_TOKEN`以外）
+3. `.env.example`を`.env`にコピーして、必要な情報を入力（`REFRESH_TOKEN`以外）
    ```
    cp .env.example .env
    ```
 
 ### 3. リフレッシュトークンの取得
 
-以下のコマンドを実行して、各アカウントのリフレッシュトークンを取得します。
-
-**ソースアカウントの場合:**
+以下のコマンドを実行して、リフレッシュトークンを取得します。
 
 ```bash
-pnpm get-refresh-token --account source
-```
-
-**ターゲットアカウントの場合:**
-
-```bash
-pnpm get-refresh-token --account target
+pnpm get-refresh-token
 ```
 
 コマンドを実行すると、認証用のURLが表示されます。ブラウザでそのURLを開き、Spotifyアカウントでログインして認証を許可してください。
-認証が成功すると、コンソールにリフレッシュトークンが表示されます。表示されたトークンをコピーし、`.env` ファイルの `SOURCE_REFRESH_TOKEN` または `TARGET_REFRESH_TOKEN` にそれぞれ設定してください。
+認証が成功すると、コンソールにリフレッシュトークンが表示されます。表示されたトークンをコピーし、`.env` ファイルの `REFRESH_TOKEN` に設定してください。
 
 ### 4. GitHub Actionsの設定
 
 1. GitHub上でリポジトリを作成
 2. 必要な秘密情報（Secrets）をリポジトリの設定に追加：
-   - `SOURCE_CLIENT_ID`
-   - `SOURCE_CLIENT_SECRET`
-   - `SOURCE_REFRESH_TOKEN`
-   - `TARGET_CLIENT_ID`
-   - `TARGET_CLIENT_SECRET`
-   - `TARGET_REFRESH_TOKEN`
-   - `TARGET_PLAYLIST_ID`
+   - `CLIENT_ID`
+   - `CLIENT_SECRET`
+   - `REFRESH_TOKEN`
+   - `PLAYLIST_ID`
 3. リポジトリをプッシュすると、GitHub Actionsが自動的に設定されます
 
 ## 手動実行
@@ -79,7 +67,7 @@ pnpm start
 
 ## 仕組み
 
-1. ソースユーザーのお気に入り曲を取得
-2. ターゲットプレイリストの現在の曲を取得
-3. プレイリストに未追加の曲を特定
-4. ターゲットユーザーの特定プレイリストに新しい曲を追加
+1. お気に入り曲を取得
+2. プレイリストの現在の曲を取得
+3. プレイリストに未追加の曲を特定して追加
+4. お気に入りから削除された曲をプレイリストから削除

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/express": "^5.0.1",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^20.17.28",
-    "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@types/node':
         specifier: ^20.17.28
         version: 20.19.27
-      commander:
-        specifier: ^13.1.0
-        version: 13.1.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -198,10 +195,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -646,8 +639,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  commander@13.1.0: {}
 
   content-disposition@1.0.1: {}
 

--- a/src/cli/get-refresh-token.ts
+++ b/src/cli/get-refresh-token.ts
@@ -1,11 +1,7 @@
 import path from 'node:path';
-import { Command } from 'commander';
 import dotenv from 'dotenv';
 import express from 'express';
 import { buildAuthorizeUrl, fetchAccessToken } from 'spotify-utility';
-
-// 型定義
-type AccountType = 'source' | 'target';
 
 interface SpotifyConfig {
   clientId: string;
@@ -17,18 +13,14 @@ interface SpotifyConfig {
 const requiredScopes = ['user-library-read', 'playlist-modify-public', 'playlist-modify-private'];
 
 // 設定管理
-function getConfig(accountType: AccountType): SpotifyConfig {
-  const clientId = accountType === 'source' ? process.env.SOURCE_CLIENT_ID : process.env.TARGET_CLIENT_ID;
-  const clientSecret = accountType === 'source' ? process.env.SOURCE_CLIENT_SECRET : process.env.TARGET_CLIENT_SECRET;
+function getConfig(): SpotifyConfig {
+  const clientId = process.env.CLIENT_ID;
+  const clientSecret = process.env.CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
-    console.error(`${accountType === 'source' ? 'ソース' : 'ターゲット'}アカウントの認証情報が見つかりません`);
+    console.error('アカウントの認証情報が見つかりません');
     console.error('以下の環境変数を設定してください:');
-    console.error(
-      accountType === 'source'
-        ? '  - SOURCE_CLIENT_ID\n  - SOURCE_CLIENT_SECRET'
-        : '  - TARGET_CLIENT_ID\n  - TARGET_CLIENT_SECRET',
-    );
+    console.error('  - CLIENT_ID\n  - CLIENT_SECRET');
     process.exit(1);
   }
 
@@ -50,21 +42,19 @@ class AuthServer {
     this.setupSignalHandlers();
   }
 
-  start(config: SpotifyConfig, accountType: AccountType): void {
-    this.setupRoutes(config, accountType);
+  start(config: SpotifyConfig): void {
+    this.setupRoutes(config);
     this.server = this.app.listen(8888, () => {
-      console.log(`\n${accountType === 'source' ? 'ソース' : 'ターゲット'}アカウントの認証サーバーを起動中...`);
+      console.log('\n認証サーバーを起動中...');
       console.log('http://127.0.0.1:8888/login にアクセスしてください');
     });
 
     this.setupTimeout();
   }
 
-  private setupRoutes(config: SpotifyConfig, accountType: AccountType): void {
+  private setupRoutes(config: SpotifyConfig): void {
     this.app.get('/login', (req, res) => {
-      console.log(
-        `\nSpotify認証ページへリダイレクトします (${accountType === 'source' ? 'ソース' : 'ターゲット'}アカウント)...`,
-      );
+      console.log('\nSpotify認証ページへリダイレクトします...');
       const authorizeUrl = buildAuthorizeUrl(config.clientId, config.redirectUri, requiredScopes);
       res.redirect(authorizeUrl);
     });
@@ -81,16 +71,11 @@ class AuthServer {
       try {
         const accessToken = await fetchAccessToken(config.clientId, config.clientSecret, code, config.redirectUri);
         console.log('\n--- 認証成功 ---');
-        console.log(`アカウントタイプ: ${accountType === 'source' ? 'ソース' : 'ターゲット'}`);
         console.log('リフレッシュトークン:', accessToken.refresh_token);
         console.log('-----------------');
-        console.log(
-          `\n上記のリフレッシュトークンを.envファイルの${accountType === 'source' ? 'SOURCE_REFRESH_TOKEN' : 'TARGET_REFRESH_TOKEN'}にコピーしてください`,
-        );
+        console.log('\n上記のリフレッシュトークンを.envファイルのREFRESH_TOKENにコピーしてください');
 
-        res.send(
-          `${accountType === 'source' ? 'ソース' : 'ターゲット'}アカウントの認証が完了しました。このウィンドウを閉じてください。`,
-        );
+        res.send('認証が完了しました。このウィンドウを閉じてください。');
       } catch (error) {
         console.error('\n認証コードの取得中にエラーが発生:', error);
         res.status(500).send('認証中にエラーが発生しました');
@@ -131,21 +116,10 @@ class AuthServer {
 
 // メイン処理
 function main() {
-  const program = new Command();
-  program.requiredOption('-a, --account <type>', "アカウントタイプ: 'source' または 'target'").parse(process.argv);
-
-  const options = program.opts();
-  const accountType = options.account as AccountType;
-
-  if (accountType !== 'source' && accountType !== 'target') {
-    console.error("無効なアカウントタイプです。'source' または 'target' を指定してください。");
-    process.exit(1);
-  }
-
   dotenv.config({ path: path.resolve(process.cwd(), '.env') });
-  const config = getConfig(accountType);
+  const config = getConfig();
   const server = new AuthServer();
-  server.start(config, accountType);
+  server.start(config);
 }
 
 main();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -4,15 +4,7 @@ import { Config } from './types';
 dotenv.config();
 
 export function loadEnvConfig(): Config {
-  const requiredEnvVars = [
-    'SOURCE_CLIENT_ID',
-    'SOURCE_CLIENT_SECRET',
-    'SOURCE_REFRESH_TOKEN',
-    'TARGET_CLIENT_ID',
-    'TARGET_CLIENT_SECRET',
-    'TARGET_REFRESH_TOKEN',
-    'TARGET_PLAYLIST_ID',
-  ];
+  const requiredEnvVars = ['CLIENT_ID', 'CLIENT_SECRET', 'REFRESH_TOKEN', 'PLAYLIST_ID'];
 
   const missingEnvVars = requiredEnvVars.filter((varName) => !process.env[varName]);
 
@@ -21,13 +13,10 @@ export function loadEnvConfig(): Config {
   }
 
   return {
-    sourceClientId: process.env.SOURCE_CLIENT_ID as string,
-    sourceClientSecret: process.env.SOURCE_CLIENT_SECRET as string,
-    sourceRefreshToken: process.env.SOURCE_REFRESH_TOKEN as string,
-    targetClientId: process.env.TARGET_CLIENT_ID as string,
-    targetClientSecret: process.env.TARGET_CLIENT_SECRET as string,
-    targetRefreshToken: process.env.TARGET_REFRESH_TOKEN as string,
-    targetPlaylistId: process.env.TARGET_PLAYLIST_ID as string,
+    clientId: process.env.CLIENT_ID as string,
+    clientSecret: process.env.CLIENT_SECRET as string,
+    refreshToken: process.env.REFRESH_TOKEN as string,
+    playlistId: process.env.PLAYLIST_ID as string,
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -2,11 +2,8 @@
  * アプリケーション設定の型定義
  */
 export interface Config {
-  readonly sourceClientId: string;
-  readonly sourceClientSecret: string;
-  readonly sourceRefreshToken: string;
-  readonly targetClientId: string;
-  readonly targetClientSecret: string;
-  readonly targetRefreshToken: string;
-  readonly targetPlaylistId: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly refreshToken: string;
+  readonly playlistId: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,24 +7,18 @@ async function main() {
     const config = getConfig();
 
     // クライアントの初期化
-    const sourceClient = await createSpotifyUtility({
-      clientId: config.sourceClientId,
-      clientSecret: config.sourceClientSecret,
-      refreshToken: config.sourceRefreshToken,
-    });
-
-    const targetClient = await createSpotifyUtility({
-      clientId: config.targetClientId,
-      clientSecret: config.targetClientSecret,
-      refreshToken: config.targetRefreshToken,
+    const client = await createSpotifyUtility({
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      refreshToken: config.refreshToken,
     });
 
     // 情報取得
     console.log('お気に入り曲を取得中...');
-    const savedTrackUris = await sourceClient.tracks.listMyFavoriteUris();
+    const savedTrackUris = await client.tracks.listMyFavoriteUris();
     console.log(`${savedTrackUris.size}件のお気に入り曲を取得`);
     console.log('プレイリストの曲を取得中...');
-    const playlistTrackUris = await targetClient.playlists.listTrackUris(config.targetPlaylistId);
+    const playlistTrackUris = await client.playlists.listTrackUris(config.playlistId);
     console.log(`${playlistTrackUris.size}件のプレイリスト曲を取得`);
     console.log('差分を確認中...');
 
@@ -33,7 +27,7 @@ async function main() {
     console.log(`${newTrackUris.size}件の新規追加曲を検出`);
     if (newTrackUris.size > 0) {
       console.log('プレイリストに新規追加曲を追加中...');
-      await targetClient.playlists.addTracks(config.targetPlaylistId, newTrackUris);
+      await client.playlists.addTracks(config.playlistId, newTrackUris);
     } else {
       console.log('新規追加曲なし');
     }
@@ -43,7 +37,7 @@ async function main() {
     console.log(`${deletedTrackUris.size}件の削除曲を検出`);
     if (deletedTrackUris.size > 0) {
       console.log('プレイリストから削除曲を削除中...');
-      await targetClient.playlists.removeTracks(config.targetPlaylistId, deletedTrackUris);
+      await client.playlists.removeTracks(config.playlistId, deletedTrackUris);
     } else {
       console.log('削除曲なし');
     }


### PR DESCRIPTION
# 概要

2つのSpotifyアカウントを前提とした設計から、1つのアカウントを使用する設計にリファクタリングしました。

## 主な変更内容

- 型定義を単一アカウントベースに変更
- 環境変数を6つから4つに削減
- クライアントインスタンスを1つに統合
- CLIツールを簡素化（--accountオプションを削除）
- ドキュメントを更新

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)